### PR TITLE
Fall back to stripping whitespace on translation lookup

### DIFF
--- a/spec/fixtures/tmx/files/whitespace.tmx.erb
+++ b/spec/fixtures/tmx/files/whitespace.tmx.erb
@@ -1,0 +1,10 @@
+<tmx version="1.4">
+  <body>
+    <tu tuid="abc123" segtype="block">
+      <prop type="x-smartling-string-variant">en.foo.bar</prop>
+      <tuv xml:lang="en-US"><seg>foobar
+baz</seg></tuv>
+      <tuv xml:lang="de-DE"><seg>foosbar</seg></tuv>
+    </tu>
+  </body>
+</tmx>

--- a/spec/translation_memory_spec.rb
+++ b/spec/translation_memory_spec.rb
@@ -213,6 +213,22 @@ describe TranslationMemory do
       end
     end
 
+    context 'with a translation containing extraneous whitespace' do
+      let(:tmx_contents) do
+        TmxFixture.load('whitespace')
+      end
+
+      it "matches even if the phrase key doesn't contain the same whitespace" do
+        phrase = InMemoryDataStore::Phrase.create(
+          key: 'foobarbaz',
+          meta_key: 'foo.bar'
+        )
+
+        trans = memory.translation_for(locale, phrase)
+        expect(trans).to eq('foosbar')
+      end
+    end
+
     context 'with a translation memory containing non-normalized text' do
       let(:tmx_contents) do
         TmxFixture.load('single', {


### PR DESCRIPTION
Attempts to look translations up by stripping whitespace if no translation candidates can be determined via exact key/meta key match.

For example, if the string `foo\nbar` exists in our database but not in Smartling (Smartling does not consider whitespace significant when it "smart" matches new content), an exact match will fail - the only difference is the (probably insignificant) extra `\n` character. In cases like this, strip the whitespace and match on the stripped text.

@jdoconnor @11mdlow @zvkemp @seunghyo 
