### PR TITLE
Match translations with HTML entities

### DIFF
--- a/lib/rosette/tms/smartling-tms/translation_memory.rb
+++ b/lib/rosette/tms/smartling-tms/translation_memory.rb
@@ -109,7 +109,6 @@ module Rosette
         end
 
         def resolves_with_html_entities?(key, variant)
-          binding.pry
           replace_entities(key).eql?(replace_entities(variant))
         end
 

--- a/rosette-tms-smartling.gemspec
+++ b/rosette-tms-smartling.gemspec
@@ -13,11 +13,12 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.has_rdoc = true
 
+  s.add_dependency 'concurrent-ruby', '~> 0.7'
+  s.add_dependency 'htmlentities', '~> 4.3'
   s.add_dependency 'nokogiri', '1.6'
   s.add_dependency 'smartling', '~> 0.5'
-  s.add_dependency 'twitter_cldr', '~> 3.2'
-  s.add_dependency 'concurrent-ruby', '~> 0.7'
   s.add_dependency 'tmx-parser', '~> 1.0'
+  s.add_dependency 'twitter_cldr', '~> 3.2'
 
   s.require_path = 'lib'
   s.files = Dir["{lib,spec}/**/*", 'Gemfile', 'History.txt', 'README.md', 'Rakefile', 'rosette-tms-smartling.gemspec']

--- a/spec/fixtures/tmx/files/html_entities.tmx.erb
+++ b/spec/fixtures/tmx/files/html_entities.tmx.erb
@@ -1,0 +1,9 @@
+<tmx version="1.4">
+  <body>
+    <tu tuid="abc123" segtype="block">
+      <prop type="x-smartling-string-variant">en.foo.bar</prop>
+      <tuv xml:lang="en-US"><seg>← Other Awesome Games</seg></tuv>
+      <tuv xml:lang="de-DE"><seg>← Andere Awesome-Spiele</seg></tuv>
+    </tu>
+  </body>
+</tmx>

--- a/spec/translation_memory_spec.rb
+++ b/spec/translation_memory_spec.rb
@@ -245,6 +245,22 @@ describe TranslationMemory do
       end
     end
 
+    context 'with a translation containing html entities' do
+      let(:tmx_contents) do
+        TmxFixture.load('html_entities')
+      end
+
+      it 'returns the correct translation' do
+        phrase = InMemoryDataStore::Phrase.create(
+          key: '&larr; Other Awesome Games',
+          meta_key: 'foo.bar'
+        )
+
+        trans = memory.translation_for(locale, phrase)
+        expect(trans).to eq('← Andere Awesome-Spiele')
+      end
+    end
+
     context 'with a translation memory containing non-normalized text' do
       let(:tmx_contents) do
         TmxFixture.load('single', {


### PR DESCRIPTION
Translations that contain HTML entities are occasionally not matched because Smartling returns them decoded in memory dumps.

@jdoconnor @11mdlow @zvkemp @seunghyo 
