### PR TITLE
Add option to push strings to Smartling by branch name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby '2.0.0', engine: 'jruby', engine_version: '1.7.15'
 
 gemspec
 
-gem 'rosette-core', github: 'rosette-proj/rosette-core'
+gem 'rosette-core', github: 'rosette-proj/rosette-core', branch: 'push_by_branch'
 
 group :development, :test do
   gem 'activemodel'

--- a/lib/rosette/tms/smartling-tms/configurator.rb
+++ b/lib/rosette/tms/smartling-tms/configurator.rb
@@ -5,12 +5,15 @@ module Rosette
     module SmartlingTms
 
       class Configurator
+        PhraseStorageGranularity = Rosette::Queuing::Commits::PhraseStorageGranularity
+
         DEFAULT_PARSE_FREQUENCY = 3600  # one hour in seconds
         DEFAULT_THREAD_POOL_SIZE = 10
+        DEFAULT_PHRASE_STORAGE_GRANULARITY = PhraseStorageGranularity::COMMIT
 
         attr_reader :rosette_config, :repo_config
         attr_reader :api_options, :serializer_id, :directives, :parse_frequency
-        attr_reader :thread_pool_size
+        attr_reader :thread_pool_size, :phrase_storage_granularity
 
         def initialize(rosette_config, repo_config)
           @api_options = {}
@@ -20,6 +23,7 @@ module Rosette
           @repo_config = repo_config
           @thread_pool_size = DEFAULT_THREAD_POOL_SIZE
           @parse_frequency = DEFAULT_PARSE_FREQUENCY
+          @phrase_storage_granularity = DEFAULT_PHRASE_STORAGE_GRANULARITY
         end
 
         # Options used to build a SmartlingApi that can communicate with the
@@ -44,6 +48,10 @@ module Rosette
 
         def set_thread_pool_size(thread_pool_size)
           @thread_pool_size = thread_pool_size
+        end
+
+        def set_phrase_storage_granularity(granularity)
+          @phrase_storage_granularity = granularity
         end
 
         def smartling_api

--- a/lib/rosette/tms/smartling-tms/repository.rb
+++ b/lib/rosette/tms/smartling-tms/repository.rb
@@ -26,12 +26,12 @@ module Rosette
           lookup_translations(locale, [phrase]).first
         end
 
-        def store_phrases(phrases, commit_id, granularity = PhraseStorageGranularity::COMMIT)
-          file = SmartlingFile.new(configurator, commit_id, granularity)
+        def store_phrases(phrases, commit_id)
+          file = SmartlingFile.new(configurator, commit_id)
           file.upload(phrases)
         end
 
-        def store_phrase(phrase, commit_id, granularity = PhraseStorageGranularity::COMMIT)
+        def store_phrase(phrase, commit_id)
           store_phrases([phrase], commit_id)
         end
 

--- a/lib/rosette/tms/smartling-tms/repository.rb
+++ b/lib/rosette/tms/smartling-tms/repository.rb
@@ -26,12 +26,12 @@ module Rosette
           lookup_translations(locale, [phrase]).first
         end
 
-        def store_phrases(phrases, commit_id)
-          file = SmartlingFile.new(configurator, commit_id)
+        def store_phrases(phrases, commit_id, granularity = PhraseStorageGranularity::COMMIT)
+          file = SmartlingFile.new(configurator, commit_id, granularity)
           file.upload(phrases)
         end
 
-        def store_phrase(phrase, commit_id)
+        def store_phrase(phrase, commit_id, granularity = PhraseStorageGranularity::COMMIT)
           store_phrases([phrase], commit_id)
         end
 

--- a/lib/rosette/tms/smartling-tms/smartling_file.rb
+++ b/lib/rosette/tms/smartling-tms/smartling_file.rb
@@ -25,15 +25,16 @@ module Rosette
         end
 
         def file_uri
-          filename = if branch_uri?
-            commit_log.branch_name
+          if branch_uri?
+            filename = commit_log.branch_name
+            author = 'rosette'
           else
-            commit_id
+            filename = commit_id
+            author = get_identity_string(rev_commit)
           end
 
           File.join(
-            repo_config.name,
-            get_identity_string(rev_commit),
+            repo_config.name, author,
             "#{filename}#{serializer_const.default_extension}"
           )
         end

--- a/lib/rosette/tms/smartling-tms/smartling_file.rb
+++ b/lib/rosette/tms/smartling-tms/smartling_file.rb
@@ -9,12 +9,11 @@ module Rosette
       class SmartlingFile
         PhraseStorageGranularity = Rosette::Queuing::Commits::PhraseStorageGranularity
 
-        attr_reader :configurator, :commit_id, :statuses, :granularity
+        attr_reader :configurator, :commit_id, :statuses
 
-        def initialize(configurator, commit_id, granularity = PhraseStorageGranularity::COMMIT)
+        def initialize(configurator, commit_id)
           @configurator = configurator
           @commit_id = commit_id
-          @granularity = granularity
         end
 
         def phrase_count
@@ -149,6 +148,10 @@ module Rosette
           @commit_log ||= rosette_config.datastore.lookup_commit_log(
             repo_config.name, commit_id
           )
+        end
+
+        def granularity
+          configurator.phrase_storage_granularity
         end
 
         def rev_commit

--- a/lib/rosette/tms/smartling-tms/smartling_locale_status.rb
+++ b/lib/rosette/tms/smartling-tms/smartling_locale_status.rb
@@ -5,12 +5,12 @@ module Rosette
     module SmartlingTms
 
       class SmartlingLocaleStatus
-        attr_reader :repo_name, :commit_id
+        attr_reader :repo_name, :ref
         attr_reader :phrase_count, :translated_count, :file_uri
 
-        def initialize(repo_name, commit_id, phrase_count, translated_count, file_uri)
+        def initialize(repo_name, ref, phrase_count, translated_count, file_uri)
           @repo_name = repo_name
-          @commit_id = commit_id
+          @ref = ref
           @phrase_count = phrase_count
           @translated_count = translated_count
           @file_uri = file_uri
@@ -18,13 +18,14 @@ module Rosette
 
         def self.from_api_response(response)
           file_uri = response['fileUri']
-          repo_name, author, commit_id = file_uri.split('/')
-          commit_id = commit_id.chomp(File.extname(commit_id)) if commit_id
+          repo_name, author, *ref = file_uri.split('/')
+          ref = ref.join('/')
+          ref = ref.chomp(File.extname(ref))
           phrase_count = response['stringCount']
           translated_count = response['completedStringCount']
 
           new(
-            repo_name, commit_id, phrase_count,
+            repo_name, ref, phrase_count,
             translated_count, file_uri
           )
         end

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -14,6 +14,7 @@ describe Repository do
 
   let(:fixture) do
     load_repo_fixture(repo_name) do |config, repo_config|
+      config.use_datastore('in-memory')
       repo_config.add_locale(locale_code)
       repo_config.use_tms('smartling') do |tms_config|
         tms_config.set_serializer('test/test')
@@ -42,6 +43,17 @@ describe Repository do
   end
 
   let(:file) { SmartlingFile.new(configurator, commit_id) }
+
+  let!(:commit_log) do
+    InMemoryDataStore::CommitLog.create(
+      status: PhraseStatus::FETCHED,
+      repo_name: repo_name,
+      commit_id: commit_id,
+      phrase_count: 0,
+      commit_datetime: nil,
+      branch_name: 'refs/heads/origin/master'
+    )
+  end
 
   context 'with a translation memory' do
     let(:tmx_fixture) { TmxFixture.load('double') }

--- a/spec/smartling_file_spec.rb
+++ b/spec/smartling_file_spec.rb
@@ -66,7 +66,11 @@ describe SmartlingFile do
 
   let(:phrase) { InMemoryDataStore::Phrase.create(key: 'foobar', meta_key: 'foo.bar') }
   let(:granularity) { Commits::PhraseStorageGranularity::COMMIT }
-  let(:file) { SmartlingFile.new(configurator, commit_id, granularity) }
+  let(:file) { SmartlingFile.new(configurator, commit_id) }
+
+  before(:each) do
+    configurator.set_phrase_storage_granularity(granularity)
+  end
 
   context 'with a canned status from the smartling api' do
     before(:each) do

--- a/spec/smartling_file_spec.rb
+++ b/spec/smartling_file_spec.rb
@@ -149,9 +149,9 @@ describe SmartlingFile do
       let(:granularity) { Commits::PhraseStorageGranularity::BRANCH }
 
       describe '#file_uri' do
-        it 'adds the git user, repo name, and branch name to the filename' do
+        it 'adds the repo name and branch name to the filename' do
           expect(file.file_uri).to eq(
-            "#{repo_name}/#{git_user}/#{commit_log.branch_name}.txt"
+            "#{repo_name}/rosette/#{commit_log.branch_name}.txt"
           )
         end
       end

--- a/spec/smartling_locale_status_spec.rb
+++ b/spec/smartling_locale_status_spec.rb
@@ -11,14 +11,30 @@ describe SmartlingLocaleStatus do
     it 'extracts the repo name and commit id from the api response hash' do
       hash = create_file_entry(
         'repo_name' => 'awesome_repo',
-        'commit_id' => 'abc123',
+        'ref' => 'abc123',
         'author' => 'KathrynJaneway'
       )
 
       smartling_file_status.from_api_response(hash).tap do |file|
         expect(file.repo_name).to eq('awesome_repo')
-        expect(file.commit_id).to eq('abc123')
+        expect(file.ref).to eq('abc123')
         expect(file.file_uri).to eq('awesome_repo/KathrynJaneway/abc123.yml')
+      end
+    end
+
+    it 'extracts the repo name and branch name from the api response hash' do
+      hash = create_file_entry(
+        'repo_name' => 'awesome_repo',
+        'ref' => 'refs/remotes/origin/my_branch',
+        'author' => 'KathrynJaneway'
+      )
+
+      smartling_file_status.from_api_response(hash).tap do |file|
+        expect(file.repo_name).to eq('awesome_repo')
+        expect(file.ref).to eq('refs/remotes/origin/my_branch')
+        expect(file.file_uri).to eq(
+          'awesome_repo/KathrynJaneway/refs/remotes/origin/my_branch.yml'
+        )
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,12 +37,12 @@ RSpec.configure do |config|
     Rosette::DataStores::InMemoryDataStore.all_entries.clear
   end
 
-  def create_file_uri(repo_name, author, commit_id)
-    "#{repo_name}/#{author}/#{commit_id}.yml"
+  def create_file_uri(repo_name, author, ref)
+    "#{repo_name}/#{author}/#{ref}.yml"
   end
 
-  def create_tmp_file_uri(repo_name, commit_id)
-    "#{repo_name}/#{commit_id}.yml"
+  def create_tmp_file_uri(repo_name, ref)
+    "#{repo_name}/#{ref}.yml"
   end
 
   def fake_hex_string(length = 10)
@@ -58,7 +58,7 @@ RSpec.configure do |config|
       'fileUri' => options['fileUri'] || create_file_uri(
         options.fetch('repo_name', fake_string),
         options.fetch('author', "#{fake_string} #{fake_string}"),
-        options.fetch('commit_id', fake_hex_string(38))
+        options.fetch('ref', fake_hex_string(38))
       ),
       'stringCount' => options.fetch('stringCount', 1),
       'wordCount' => options.fetch('wordCount', 2),
@@ -73,7 +73,7 @@ RSpec.configure do |config|
     create_file_entry(options).merge(
       'fileUri' => create_tmp_file_uri(
         options.fetch('repo_name', fake_string),
-        options.fetch('commit_id', fake_hex_string(38))
+        options.fetch('ref', fake_hex_string(38))
       )
     )
   end


### PR DESCRIPTION
Companion pull request: [https://github.com/rosette-proj/rosette-core/pull/16](https://github.com/rosette-proj/rosette-core/pull/16)

Adds a third argument to `Repository#store_phrases` that indicates the phrase storage "granularity", i.e. if the phrases given are from a single commit or from an entire branch. Depending on the granularity, rosette-tms-smartling uploads files to Smartling with different file names. If the granularity is `COMMIT`, the file name will look something like `lumos_rails/abMatGit/05a3be022455ee93de469568ef42c0a557e280ca.yml`. If the granularity is instead `BRANCH`, the file name will be something like `lumos_rails/abMatGit/refs/remotes/origin/team_profiles.yml`. This allows us to group phrases by branch, which should lead to less noise for our CS team to wade through. Currently, phrases are only uploaded by commit, meaning that spelling corrections and variant/meta key changes (which result in new commit ids) appear in Smartling. Adriana then has to weed through a bunch of slightly different copies of the same string, rejecting the bad ones. Often this means she also has to contact the engineer who uploaded them to ask which version should actually be translated.

@jdoconnor @11mdlow @zvkemp @seunghyo
