### PR TITLE
Properly detect phrases that contain wrapping HTML tags

### DIFF
--- a/lib/rosette/tms/smartling-tms/translation_memory.rb
+++ b/lib/rosette/tms/smartling-tms/translation_memory.rb
@@ -90,27 +90,21 @@ module Rosette
 
         def resolve_units(units, locale, phrase)
           candidates = resolve_units_with_pipeline(units, locale, phrase)
+          return candidates unless candidates.empty?
 
-          if candidates.empty?
-            opening_tag, closing_tag = get_wrapping_html_tags(phrase.key)
+          opening_tag, closing_tag = get_wrapping_html_tags(phrase.key)
+          return [] unless opening_tag && closing_tag
 
-            if opening_tag && closing_tag
-              units = units.map do |unit|
-                unit.copy.tap do |unit_copy|
-                  unit_copy.variants.each do |variant|
-                    variant.elements.insert(0, opening_tag)
-                    variant.elements << closing_tag
-                  end
-                end
+          units.map! do |unit|
+            unit.copy.tap do |unit_copy|
+              unit_copy.variants.each do |variant|
+                variant.elements.insert(0, opening_tag)
+                variant.elements << closing_tag
               end
-
-              resolve_units_with_pipeline(units, locale, phrase)
-            else
-              []
             end
-          else
-            candidates
           end
+
+          resolve_units_with_pipeline(units, locale, phrase)
         end
 
         def get_wrapping_html_tags(str)

--- a/lib/rosette/tms/smartling-tms/translation_memory.rb
+++ b/lib/rosette/tms/smartling-tms/translation_memory.rb
@@ -89,6 +89,41 @@ module Rosette
         end
 
         def resolve_units(units, locale, phrase)
+          candidates = resolve_units_with_pipeline(units, locale, phrase)
+
+          if candidates.empty?
+            opening_tag, closing_tag = get_wrapping_html_tags(phrase.key)
+
+            if opening_tag && closing_tag
+              units = units.map do |unit|
+                unit.copy.tap do |unit_copy|
+                  unit_copy.variants.each do |variant|
+                    variant.elements.insert(0, opening_tag)
+                    variant.elements << closing_tag
+                  end
+                end
+              end
+
+              resolve_units_with_pipeline(units, locale, phrase)
+            else
+              []
+            end
+          else
+            candidates
+          end
+        end
+
+        def get_wrapping_html_tags(str)
+          if str =~ /\A(<[^>]+>)/
+            opening_tag = $1
+
+            if str =~ /(<\/[^>]+>)\z/
+              [opening_tag, $1]
+            end
+          end
+        end
+
+        def resolve_units_with_pipeline(units, locale, phrase)
           RESOLVE_PIPELINE.each do |step|
             candidates = units.select do |unit|
               can_resolve?(unit, locale, phrase) do |key, variant|
@@ -119,11 +154,15 @@ module Rosette
         def can_resolve?(unit, locale, phrase)
           placeholder_map = build_placeholder_map(phrase, unit)
 
-          if variant = find_variant(unit, repo_config.source_locale)
+          if variant = source_variant_for(unit)
             yield phrase.key, resolve_variant(variant, placeholder_map)
           else
             false
           end
+        end
+
+        def source_variant_for(unit)
+          find_variant(unit, repo_config.source_locale)
         end
 
         def replace_entities(str)

--- a/rosette-tms-smartling.gemspec
+++ b/rosette-tms-smartling.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'htmlentities', '~> 4.3'
   s.add_dependency 'nokogiri', '1.6'
   s.add_dependency 'smartling', '~> 0.5'
-  s.add_dependency 'tmx-parser', '~> 1.0'
+  s.add_dependency 'tmx-parser', '~> 1.1'
   s.add_dependency 'twitter_cldr', '~> 3.2'
 
   s.require_path = 'lib'

--- a/spec/fixtures/tmx/files/wrapping_html.tmx.erb
+++ b/spec/fixtures/tmx/files/wrapping_html.tmx.erb
@@ -1,0 +1,9 @@
+<tmx version="1.4">
+  <body>
+    <tu tuid="abc123" segtype="block">
+      <prop type="x-smartling-string-variant">en.foo.bar</prop>
+      <tuv xml:lang="en-US"><seg>Our use of cookies</seg></tuv>
+      <tuv xml:lang="de-DE"><seg>Verwendung von Cookies</seg></tuv>
+    </tu>
+  </body>
+</tmx>

--- a/spec/translation_memory_spec.rb
+++ b/spec/translation_memory_spec.rb
@@ -261,6 +261,22 @@ describe TranslationMemory do
       end
     end
 
+    context 'with a phrase containing wrapping html tags' do
+      let(:tmx_contents) do
+        TmxFixture.load('wrapping_html')
+      end
+
+      it "returns the translation wrapped in the same tags (even though the tags don't officially exist)" do
+        phrase = InMemoryDataStore::Phrase.create(
+          key: '<u>Our use of cookies</u>',
+          meta_key: 'foo.bar'
+        )
+
+        trans = memory.translation_for(locale, phrase)
+        expect(trans).to eq('<u>Verwendung von Cookies</u>')
+      end
+    end
+
     context 'with a translation memory containing non-normalized text' do
       let(:tmx_contents) do
         TmxFixture.load('single', {


### PR DESCRIPTION
Smartling strips wrapping HTML tags from translations in TMX dumps. In other words, if we have a phrase like this: `<u>Our use of cookies</u>`, it appears like this in the TMX: `Our use of cookies`. This makes it really hard to identify the translation. The solution is to identify when a string contains wrapping HTML tags, look up the translation using the wrapped phrase, and then wrap the actual translation in the tags as well.

@jdoconnor @11mdlow @zvkemp @seunghyo 
