### PR TITLE
Support Smartling's tricky HTML placeholder nonsense

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Gemfile.lock
 .DS_Store
 pkg/
 classpath.txt
+tester.rb

--- a/lib/rosette/tms/smartling-tms.rb
+++ b/lib/rosette/tms/smartling-tms.rb
@@ -7,6 +7,7 @@ module Rosette
   module Tms
 
     module SmartlingTms
+      autoload :PlaceholderScanner,          'rosette/tms/smartling-tms/placeholder_scanner'
       autoload :SmartlingApi,                'rosette/tms/smartling-tms/smartling_api'
       autoload :SmartlingUploader,           'rosette/tms/smartling-tms/smartling_uploader'
       autoload :SmartlingDownloader,         'rosette/tms/smartling-tms/smartling_downloader'

--- a/lib/rosette/tms/smartling-tms/placeholder_scanner.rb
+++ b/lib/rosette/tms/smartling-tms/placeholder_scanner.rb
@@ -1,0 +1,90 @@
+# encoding: UTF-8
+
+require 'nokogiri'
+
+module Rosette
+  module Tms
+    module SmartlingTms
+
+      class PlaceholderScanner
+        HTML_TAG_REGEX = /(<\/?\w+\s*(?:\w+\s*=\s*".*?"|'.*?'|[^'">\s]\s*)*>)/
+        HTML_ATTRIBUTE_REGEX = /\w+\s*=\s*(".*?"|'.*?'|[^'">\s]\s*)*/
+        SMARTLING_PH_REGEX = /(\{ph:\\?\{\d+\\?\}\})/
+
+        attr_reader :regexes, :html_attributes
+        alias_method :identify_html_attributes?, :html_attributes
+
+        def initialize(regexes, html_attributes = true)
+          @regexes = regexes
+          @html_attributes = html_attributes
+        end
+
+        def scan(text)
+          process_next(text, pipeline, -1)
+        end
+
+        protected
+
+        def odd_map(list, pipeline, pipe_idx)
+          list.flat_map.with_index do |element, idx|
+            if idx % 2 == 1
+              if block_given?
+                yield element
+              else
+                element
+              end
+            else
+              process_next(element, pipeline, pipe_idx)
+            end
+          end
+        end
+
+        def process_next(token, pipeline, pipe_idx)
+          if pipe = pipeline[pipe_idx + 1]
+            send("process_#{pipe}", token, pipeline, pipe_idx + 1)
+          end
+        end
+
+        def process_html(token, pipeline, pipe_idx)
+          odd_map(token.split(HTML_TAG_REGEX), pipeline, pipe_idx) do |tag|
+            tag.scan(HTML_ATTRIBUTE_REGEX).flatten.map do |frag|
+              strip_quotes(frag)
+            end
+          end
+        end
+
+        def process_regexes(token, pipeline, pipe_idx)
+          odd_map(token.split(regex_union), pipeline, pipe_idx)
+        end
+
+        def process_smartling_ph(token, pipeline, pipe_idx)
+          odd_map(token.split(SMARTLING_PH_REGEX), pipeline, pipe_idx)
+        end
+
+        def strip_quotes(text)
+          first = text[0]
+          last = text[text.size - 1]
+
+          if (first == '"' && last == '"') || (first == "'") && last == "'"
+            text[1..-2]
+          else
+            text
+          end
+        end
+
+        def regex_union
+          @regex_union ||= Regexp.new("(#{Regexp.union(regexes).source})")
+        end
+
+        def pipeline
+          @pipeline ||= [].tap do |pl|
+            pl << :html if identify_html_attributes?
+            pl << :smartling_ph
+            pl << :regexes
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/rosette/tms/smartling-tms/placeholder_scanner.rb
+++ b/lib/rosette/tms/smartling-tms/placeholder_scanner.rb
@@ -42,6 +42,8 @@ module Rosette
         def process_next(token, pipeline, pipe_idx)
           if pipe = pipeline[pipe_idx + 1]
             send("process_#{pipe}", token, pipeline, pipe_idx + 1)
+          else
+            []
           end
         end
 

--- a/lib/rosette/tms/smartling-tms/translation_memory.rb
+++ b/lib/rosette/tms/smartling-tms/translation_memory.rb
@@ -199,7 +199,12 @@ module Rosette
         end
 
         def phrase_placeholders_for(phrase)
-          phrase.key.scan(placeholder_regex)
+          placeholder_scanner.scan(phrase.key)
+        end
+
+        def placeholder_scanner
+          @placeholder_scanner ||=
+            PlaceholderScanner.new(repo_config.placeholder_regexes)
         end
 
         def variant_placeholders_for(variant)
@@ -209,7 +214,7 @@ module Rosette
                 ret << el.text
               else
                 str = el.respond_to?(:text) ? el.text : el
-                ret.concat(find_inline_placeholders(str))
+                ret.concat(placeholder_scanner.scan(str))
             end
           end
         end

--- a/spec/fixtures/tmx/files/html_placeholder_attributes.tmx.erb
+++ b/spec/fixtures/tmx/files/html_placeholder_attributes.tmx.erb
@@ -1,0 +1,13 @@
+<tmx version="1.4">
+  <body>
+    <tu tuid="abc123" segtype="block">
+      <prop type="x-smartling-string-variant">en.foo.bar</prop>
+      <tuv xml:lang="en-US">
+        <seg>Enjoy easy, accessible customer service. Please visit <bpt i="3">&lt;a href=&quot;{ph:\{0\}}&quot; target=&quot;{ph:\{1\}}&quot;&gt;</bpt>Help Center<ept i="3">&lt;/a&gt;</ept> for FAQs. Or you can get a direct reply from a support agent.</seg>
+      </tuv>
+      <tuv xml:lang="de-DE">
+        <seg>Unser Customer-Service ist leicht erreichbar.  Besuchen Sie unser Help-Center und finden Sie dort zahlreiche FAQs. <bpt i="5">&lt;a href=&quot;{ph:\{0\}}&quot; target=&quot;{ph:\{1\}}&quot;&gt;</bpt><ept i="5">&lt;/a&gt;</ept>Oder erhalten Sie eine persönliche Antwort von einem unserer Support-Mitarbeiter. </seg>
+      </tuv>
+    </tu>
+  </body>
+</tmx>

--- a/spec/placeholder_scanner_spec.rb
+++ b/spec/placeholder_scanner_spec.rb
@@ -1,0 +1,51 @@
+# encoding: UTF-8
+
+require 'spec_helper'
+
+include Rosette::Tms
+
+describe SmartlingTms::PlaceholderScanner do
+  let(:regexes) { [] }
+  let(:html_attributes) { true }
+  let(:scanner) do
+    SmartlingTms::PlaceholderScanner.new(regexes, html_attributes)
+  end
+
+  it 'identifies html attributes by default' do
+    phs = scanner.scan('<a href="foo.com" target="_blank">blarg</a>')
+    expect(phs).to eq(%w(foo.com _blank))
+  end
+
+  it 'identifies special smartling "ph" placeholders' do
+    phs = scanner.scan('foo {ph:{0}} bar')
+    expect(phs).to eq(%w({ph:{0}}))
+  end
+
+  it 'identifies special smartling "ph" placeholders in html attributes' do
+    phs = scanner.scan('<a href="{ph:{0}}">blarg</a>')
+    expect(phs).to eq(%w({ph:{0}}))
+  end
+
+  context 'without html attributes' do
+    let(:html_attributes) { false }
+
+    it 'does not identify html attributes if explicitly disabled' do
+      phs = scanner.scan('<a href="foo.com" target="_blank">blarg</a>')
+      expect(phs).to eq([])
+    end
+
+    it 'identifies smartling "ph" placeholders even when html is disabled' do
+      phs = scanner.scan('<a href="{ph:{0}}">blarg</a>')
+      expect(phs).to eq(%w({ph:{0}}))
+    end
+  end
+
+  context 'with some regexes' do
+    let(:regexes) { [/%\{.+?\}/, /\{%.+?%\}/] }  # ruby and liquid
+
+    it 'identifies regex-based placeholders in the text' do
+      phs = scanner.scan("I'm a %{little} {% teapot %}")
+      expect(phs).to eq(['%{little}', '{% teapot %}'])
+    end
+  end
+end

--- a/spec/translation_memory_spec.rb
+++ b/spec/translation_memory_spec.rb
@@ -261,6 +261,29 @@ describe TranslationMemory do
       end
     end
 
+    context 'with a translation containing placeholders in html attributes' do
+      let(:tmx_contents) do
+        TmxFixture.load('html_placeholder_attributes')
+      end
+
+      it 'returns the correct translation' do
+        phrase = InMemoryDataStore::Phrase.create(
+          meta_key: 'foo.bar',
+          key: 'Enjoy easy, accessible customer service. Please visit '\
+            '<a href="%{help_link}" target="_blank">Help Center</a> '\
+            'for FAQs. Or you can get a direct reply from a support agent.'
+        )
+
+        trans = memory.translation_for(locale, phrase)
+        expect(trans).to eq(
+          'Unser Customer-Service ist leicht erreichbar.  Besuchen Sie '\
+          'unser Help-Center und finden Sie dort zahlreiche FAQs. '\
+          '<a href="%{help_link}" target="_blank"></a>Oder erhalten Sie '\
+          'eine persönliche Antwort von einem unserer Support-Mitarbeiter. '
+        )
+      end
+    end
+
     context 'with a phrase containing wrapping html tags' do
       let(:tmx_contents) do
         TmxFixture.load('wrapping_html')


### PR DESCRIPTION
In translation memory dumps, Smartling uses a secondary, inline placeholder format when it detects placeholders in paired tag attributes (i.e. HTML tag attributes). For example, this string

```
I'm a little <a href="%{link}">teapot</a>
```

becomes

``` xml
I'm a little <bpt>&lt;a href=&quot;{ph:\{0\}}&quot;&gt;</bpt>teapot<ept>&lt;/a&gt;</ept>
```

in the .tmx file. Notice the placeholder `{ph:{0}}`. The `TranslationMemory` class already handles these special placeholders, but it turns out Smartling treats HTML a little differently than I initially thought.

For some reason, Smartling treats _every_ HTML attribute as a placeholder, which means this string

```
I'm a little <a href="%{link}" target="_blank">teapot</a>
```

becomes

``` xml
I'm a little
<bpt>&lt;a href=&quot;{ph:\{0\}}&quot; target=&quot;{ph:\{1\}}&quot;&gt;</bpt>
teapot<ept>&lt;/a&gt;</ept>
```

(carriage returns added for clarity). Since none of the placeholder regexes handle this case, certain translation lookups (specifically ones that contain HTML tag attributes with placeholders) will always fail.

@jdoconnor @11mdlow @zvkemp @seunghyo 
